### PR TITLE
Only trigger auto close on new issues

### DIFF
--- a/.github/workflows/auto_close_all_issues.yml
+++ b/.github/workflows/auto_close_all_issues.yml
@@ -1,7 +1,8 @@
 name: Auto-Close All Issues
 on:
   issues:
-  issue_comment:
+    types:
+    - opened
 jobs:
   auto_close_all_issues:
     if: ${{ !github.event.issue.pull_request }}


### PR DESCRIPTION
This will mean that the comment history isn't spammed, and that if you choose to re-open an issue, that it stays open.

When an issue is closed by a repository admin, the original reporter cannot reopen it. Therefore, `reopened` is not included in the types.

Alternatively, you can choose to disable the issues feature in the github repository settings.